### PR TITLE
Updating the nginx installation command

### DIFF
--- a/Section 3 - Terraform Provisioners/remote-exec.md
+++ b/Section 3 - Terraform Provisioners/remote-exec.md
@@ -45,7 +45,8 @@ resource "aws_instance" "myec2" {
 
  provisioner "remote-exec" {
    inline = [
-     "sudo amazon-linux-extras install -y nginx1",
+    # Updating with the latest command for Amazon Linux machine
+     "sudo yum install -y nginx",
      "sudo systemctl start nginx"
    ]
  }


### PR DESCRIPTION
**Summary**:
Updating the Nginx installation command

**Description**:
The latest command to install Nginx on an `Amazon Linux machine `is changed. In this PR, I'm updating the command so that our learners will not face issues while running `remote-exec `as I faced.

Doc Link: https://dev.to/0xfedev/how-to-install-nginx-as-reverse-proxy-and-configure-certbot-on-amazon-linux-2023-2cc9